### PR TITLE
Bsm path options

### DIFF
--- a/jpo-conflictmonitor/pom.xml
+++ b/jpo-conflictmonitor/pom.xml
@@ -138,8 +138,13 @@
       <version>${geotools.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.2-jre</version>
+    </dependency>
+    <dependency>
       <groupId>org.geotools</groupId>
-      <artifactId>gt-swing</artifactId>
+      <artifactId>gt-epsg-wkt</artifactId>
       <version>${geotools.version}</version>
     </dependency>
 

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/bsm_event/BsmEventParameters.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/bsm_event/BsmEventParameters.java
@@ -40,5 +40,15 @@ public class BsmEventParameters {
         description = "The algorithm to use for BSM event detection",
         updateType = READ_ONLY)
     String algorithm;
+
+    @ConfigData(key = "bsm.event.simplifyPath",
+        description = "Whether to simplify the LineString stored in the wktPath field of the BSM Event",
+        updateType = DEFAULT)
+    boolean simplifyPath;
+
+    @ConfigData(key = "bsm.event.simplifyPathToleranceMeters",
+        description = "The Douglas-Peucker simplification algorithm distance parameter in meters",
+        updateType = DEFAULT)
+    double simplifyPathToleranceMeters;
     
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/BsmEventTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/BsmEventTopology.java
@@ -56,6 +56,8 @@ public class BsmEventTopology
                         var processor = new BsmEventProcessor();
                         processor.setPunctuationType(punctuationType);
                         processor.setMapIndex(mapIndex);
+                        processor.setSimplifyPath(parameters.isSimplifyPath());
+                        processor.setSimplifyPathToleranceMeters(parameters.getSimplifyPathToleranceMeters());
                         return processor;
                     },
                 BSM_SOURCE);

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/utils/CoordinateConversion.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/utils/CoordinateConversion.java
@@ -1,8 +1,5 @@
 package us.dot.its.jpo.conflictmonitor.monitor.utils;
 
-import java.awt.geom.Point2D;
-
-import lombok.SneakyThrows;
 import org.geotools.geometry.DirectPosition2D;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
@@ -12,12 +9,13 @@ import org.geotools.referencing.datum.DefaultEllipsoid;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
-import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.awt.geom.Point2D;
 
 public class CoordinateConversion {
 
@@ -113,7 +111,7 @@ public class CoordinateConversion {
 
     /**
      * Finds math transforms to convert a geometry between the default Geographic Coordinate System and UTM.
-     *
+     * <p>
      * The conversion to UTM is more approximate than the Offset Centimeter coordinates used for MAPs, but is
      * useful for generating simplified geometries for display and testing.
      *

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/utils/CoordinateConversion.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/utils/CoordinateConversion.java
@@ -2,12 +2,26 @@ package us.dot.its.jpo.conflictmonitor.monitor.utils;
 
 import java.awt.geom.Point2D;
 
+import lombok.SneakyThrows;
 import org.geotools.geometry.DirectPosition2D;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
 import org.geotools.referencing.GeodeticCalculator;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.referencing.datum.DefaultEllipsoid;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CoordinateConversion {
+
+    private static final Logger logger = LoggerFactory.getLogger(CoordinateConversion.class);
 
     public static double[] offsetMToLongLat(double refLongitude, double refLatitude, double offsetX, double offsetY){
 
@@ -97,5 +111,37 @@ public class CoordinateConversion {
         return CM_PER_FOOT * feet;
     }
 
+    /**
+     * Finds math transforms to convert a geometry between the default Geographic Coordinate System and UTM.
+     *
+     * The conversion to UTM is more approximate than the Offset Centimeter coordinates used for MAPs, but is
+     * useful for generating simplified geometries for display and testing.
+     *
+     * @param gcsGeom - Geometry using geographic (long/lat) coordinates.
+     * @return {@link MathTransformPair}
+     */
+    public static MathTransformPair findGcsToUtmTransforms(Geometry gcsGeom) {
+        try {
+            Coordinate[] coordinates = gcsGeom.getCoordinates();
+            Coordinate refCoord = coordinates[0];
+            String epsg = String.format("AUTO:42001,%.2f,%.2f", refCoord.getX(), refCoord.getY());
+            CoordinateReferenceSystem crs = CRS.decode(epsg);
+            MathTransform transform = CRS.findMathTransform(DefaultGeographicCRS.WGS84, crs);
+            MathTransform inverseTransform = CRS.findMathTransform(crs, DefaultGeographicCRS.WGS84);
+            return new MathTransformPair(transform, inverseTransform);
+        } catch (Exception ex) {
+            logger.error("Exception finding coordinate transform", ex);
+            return null;
+        }
+    }
+
+    public static LineString transformLineString(LineString line, MathTransform transform) {
+        try {
+            return (LineString) JTS.transform(line, transform);
+        } catch (Exception ex) {
+            logger.error("Coordinate conversion failed, returning the LineString as is.", ex);
+            return line;
+        }
+    }
     
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/utils/MathTransformPair.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/utils/MathTransformPair.java
@@ -1,0 +1,17 @@
+package us.dot.its.jpo.conflictmonitor.monitor.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.opengis.referencing.operation.MathTransform;
+
+/**
+ * Utility class to return a forward and reverse transform
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class MathTransformPair {
+    MathTransform transform;
+    MathTransform inverseTransform;
+}

--- a/jpo-conflictmonitor/src/main/resources/application.yaml
+++ b/jpo-conflictmonitor/src/main/resources/application.yaml
@@ -368,6 +368,8 @@ bsm.event:
   outputTopic: topic.CMBsmEvents
   stateStoreName: bsm-event-state-store
   debug: false
+  simplifyPath: true
+  simplifyPathToleranceMeters: 0.5
 
 # Message Ingest
 message.ingest:

--- a/jpo-conflictmonitor/src/main/resources/application.yaml
+++ b/jpo-conflictmonitor/src/main/resources/application.yaml
@@ -369,7 +369,7 @@ bsm.event:
   stateStoreName: bsm-event-state-store
   debug: false
   simplifyPath: true
-  simplifyPathToleranceMeters: 0.5
+  simplifyPathToleranceMeters: 0.05
 
 # Message Ingest
 message.ingest:


### PR DESCRIPTION
The `wktPath` property had previously been added to the `BsmEvent` class to provide a simple way to display the BSM paths on a map. However, this property can become too large, causing the record size to exceed the maximum allowed by the default Kafka configuration, if there are a large number of BSMs in a path.

To address this, this PR adds a cartographic simplification option for the `wktPath`.   The `BsmEventProcessor` uses the Douglas-Peucker algorithm provided by JTS to simplify the path.  There are two added configurable parameters:

* `bsm.event.simplifyPath` - boolean (default true)
* `bsm.event.simplifyPathToleranceMeters` - double (The tolerance parameter, default 0.05)

The simplified path is smaller than the unsimplified by one to two orders of magnitude while preserving the geometry well enough to accurately display it on a map.  The simplification is especially efficient for sections of a path where the vehicle is traveling in a relatively straight line, but the 5cm tolerance preserves sufficient detail for curved parts of the path.

Example of path simplification (blue = unsimplified, red = simplified):

![image](https://github.com/usdot-jpo-ode/jpo-conflictmonitor/assets/39739503/b891efbb-273c-42d0-93c0-f0d315097b10)



