### PR TITLE
Use -1 instead of null for missing intersection ID/region

### DIFF
--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/map/IntersectionRegion.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/models/map/IntersectionRegion.java
@@ -1,7 +1,6 @@
 package us.dot.its.jpo.conflictmonitor.monitor.models.map;
 
 import lombok.*;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 
 @Getter
 @Setter
@@ -10,23 +9,14 @@ public class IntersectionRegion {
 
     public IntersectionRegion() {}
 
-    public IntersectionRegion(Integer intersectionId, Integer region) {
-        if (intersectionId != null && intersectionId.intValue() >= 0) {
-            this.intersectionId = intersectionId;
-        }
-        if (region != null && region.intValue() >= 0) {
-            this.region = region;
-        }
+    public IntersectionRegion(int intersectionId, int region) {
+        this.intersectionId = intersectionId;
+        this.region = region;
     }
 
-    public IntersectionRegion(ProcessedMap map) {
-        if (map == null || map.getProperties() == null) return;
-        this.intersectionId = map.getProperties().getIntersectionId();
-        this.region = map.getProperties().getRegion();
-    }
 
-    private Integer intersectionId;
-    private Integer region;
+    private int intersectionId;
+    private int region;
 
 
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/processors/BsmEventProcessor.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/processors/BsmEventProcessor.java
@@ -113,8 +113,8 @@ public class BsmEventProcessor extends ContextualProcessor<BsmRsuIdKey, OdeBsmDa
             // If the BSM is in one or more MAPs, output BSM to each intersection partition
             if (newBsmInMap) {
                 for (IntersectionRegion ir : newIntersections) {
-                    int intersectionId = ir.getIntersectionId() != null ? ir.getIntersectionId() : -1;
-                    int region = ir.getRegion() != null ? ir.getRegion() : -1;
+                    int intersectionId = ir.getIntersectionId();
+                    int region = ir.getRegion();
                     var bsmIntersectionIdKey = new BsmIntersectionIdKey(key.getBsmId(), key.getRsuId(), intersectionId, region);
                     //var record = new Record<BsmIntersectionIdKey, OdeBsmData>(bsmIntersectionIdKey, value, timestamp);
                     var intersectionRecord = inputRecord.withKey(bsmIntersectionIdKey);


### PR DESCRIPTION
Updates geojsonconverter submodule to use -1 instead of 0 to indicate missing intersection ID/region, see related PR:
[Geojson Converter PR #41](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/pull/41)

Change the `IntersectionRegion` pojo to use primitive types instead of boxed integers to avoid introducing null Intersection IDs/regions.