### PR TITLE
Add delete methods for intersection configs, and fix unspecified region = -1 in ConfigControlloer

### DIFF
--- a/jpo-conflictmonitor/scripts/ConfigController_Tests/deleteIntersection.http
+++ b/jpo-conflictmonitor/scripts/ConfigController_Tests/deleteIntersection.http
@@ -1,0 +1,2 @@
+DELETE http://localhost:8082/config/intersection/10/101010/spat.validation.lowerBound
+Accept: application/json

--- a/jpo-conflictmonitor/scripts/ConfigController_Tests/deleteIntersection_no_region.http
+++ b/jpo-conflictmonitor/scripts/ConfigController_Tests/deleteIntersection_no_region.http
@@ -1,0 +1,2 @@
+DELETE http://localhost:8082/config/intersection/111111/spat.validation.lowerBound
+Accept: application/json

--- a/jpo-conflictmonitor/scripts/ConfigController_Tests/postIntersection_no_region.http
+++ b/jpo-conflictmonitor/scripts/ConfigController_Tests/postIntersection_no_region.http
@@ -3,7 +3,7 @@ Content-Type: application/json
 
 {
   "key": "spat.validation.lowerBound",
-  "roadRegulatorID": 0,
+  "roadRegulatorID": -1,
   "intersectionID": 111111,
   "category": "",
   "value": 80,

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/ConfigController.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/ConfigController.java
@@ -92,7 +92,7 @@ public class ConfigController {
             @PathVariable(name = "intersectionId") int intersectionId,
             @PathVariable(name = "key") String key) {
         try {
-            var configKey = new IntersectionConfigKey(0, intersectionId, key);
+            var configKey = new IntersectionConfigKey(-1, intersectionId, key);
             var config = configAlgorithm.getIntersectionConfig(configKey);
             return ResponseEntity.ok(config.orElse(null));
         } catch (Exception e) {
@@ -164,7 +164,7 @@ public class ConfigController {
             @PathVariable(name = "intersectionId") int intersectionId,
             @PathVariable(name = "key") String key,
             @RequestBody IntersectionConfig<T> config) {
-        return saveIntersectionConfigHelper(0, intersectionId, key, config, false);
+        return saveIntersectionConfigHelper(-1, intersectionId, key, config, false);
     }
 
     @DeleteMapping(value = "intersection/{region}/{intersectionId}/{key}")
@@ -179,7 +179,7 @@ public class ConfigController {
     public @ResponseBody ResponseEntity<ConfigUpdateResult<Void>> deleteIntersectionConfig(
             @PathVariable(name = "intersectionId") int intersectionId,
             @PathVariable(name = "key") String key) {
-        return deleteIntersectionConfigHelper(0, intersectionId, key, false);
+        return deleteIntersectionConfigHelper(-1, intersectionId, key, false);
     }
 
     private <T> ResponseEntity<ConfigUpdateResult<T>> saveIntersectionConfigHelper(

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/ConfigController.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/ConfigController.java
@@ -197,8 +197,8 @@ public class ConfigController {
                     errMsg.format("Region in path does not match RoadRegulatorID in body %s != %s%n", region, config.getRoadRegulatorID());
                 }
             } else {
-                if (config.getRoadRegulatorID() != 0) {
-                    errMsg.format("Region is not specified in URL path, but RoadRegulatorID is non-zero in the body: %s != 0.  Use the intersection/{region}/{intersectionId}/{key} endpoint to post with the region.%n", config.getRoadRegulatorID());
+                if (config.getRoadRegulatorID() > -1) {
+                    errMsg.format("Region is not specified in URL path, but RoadRegulatorID is specified in the body: %s > -1.  Use the intersection/{region}/{intersectionId}/{key} endpoint to post with the region, or set RoadRegulatorID = -1 in the body to indicate no region.%n", config.getRoadRegulatorID());
                 }
             }
             if (intersectionId != config.getIntersectionID()) {

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithm.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithm.java
@@ -86,7 +86,11 @@ public interface ConfigAlgorithm extends ExecutableAlgorithm {
                             var logger = LoggerFactory.getLogger(ConfigAlgorithm.class);
                             logger.info("Intersection listener {}: {}", key, value);
                             final var propValue = value.getValue();
-                            configMap.putObject(value.intersectionKey(), propValue);
+                            if (value != null) {
+                                configMap.putObject(value.intersectionKey(), propValue);
+                            } else {
+                                configMap.remove(value.intersectionKey());
+                            }
                         });
                     } catch (InvalidPropertyException ex) {
                         var logger = LoggerFactory.getLogger(ConfigAlgorithm.class);

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithm.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithm.java
@@ -27,6 +27,8 @@ public interface ConfigAlgorithm extends ExecutableAlgorithm {
     <T> ConfigUpdateResult<T> updateCustomConfig(DefaultConfig<T> value) throws ConfigException;
     <T> ConfigUpdateResult<T> updateIntersectionConfig(IntersectionConfig<T> value) throws ConfigException;
 
+    ConfigUpdateResult<Void> deleteIntersectionConfig(IntersectionConfigKey configKey) throws ConfigException;
+
     void registerDefaultListener(String key, DefaultConfigListener handler);
     void registerIntersectionListener(String key, IntersectionConfigListener handler);
 

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithm.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithm.java
@@ -86,10 +86,12 @@ public interface ConfigAlgorithm extends ExecutableAlgorithm {
                             var logger = LoggerFactory.getLogger(ConfigAlgorithm.class);
                             logger.info("Intersection listener {}: {}", key, value);
                             final var propValue = value.getValue();
-                            if (value != null) {
+                            if (propValue != null) {
                                 configMap.putObject(value.intersectionKey(), propValue);
                             } else {
-                                configMap.remove(value.intersectionKey());
+                                if (configMap.containsKey(value.intersectionKey())) {
+                                    configMap.remove(value.intersectionKey());
+                                }
                             }
                         });
                     } catch (InvalidPropertyException ex) {

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/config/ConfigTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/config/ConfigTopology.java
@@ -310,8 +310,8 @@ public class ConfigTopology
 
     @Override
     public <T> Optional<IntersectionConfig<T>> getIntersectionConfig(IntersectionConfigKey configKey) {
-        if (configKey.getIntersectionId() <= 0) {
-            // Special handling for unknown region
+        if (configKey.getIntersectionId() < 0) {
+            // Special handling for unknown region (-1)
             return getIntersectionConfigUnknownRegion(configKey.getIntersectionId(), configKey.getKey());
         }
         if (streams != null) {

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/ConfigControllerTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/ConfigControllerTest.java
@@ -114,7 +114,7 @@ public class ConfigControllerTest {
 
         final String key = ConfigTestUtils.key;
         final int intersectionId = ConfigTestUtils.intersectionId;
-        final var intersectionKey = new IntersectionConfigKey(0, intersectionId, key);
+        final var intersectionKey = new IntersectionConfigKey(-1, intersectionId, key);
         final int value = 10;
 
         final var config = Optional.of(ConfigTestUtils.getIntersectionConfig_NoRegion());

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithmTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithmTest.java
@@ -153,7 +153,10 @@ public class ConfigAlgorithmTest {
             return null;
         }
 
-
+        @Override
+        public ConfigUpdateResult<Void> deleteIntersectionConfig(IntersectionConfigKey configKey) throws ConfigException {
+            return null;
+        }
 
 
         @Override

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithmTest.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/monitor/algorithms/config/ConfigAlgorithmTest.java
@@ -80,6 +80,14 @@ public class ConfigAlgorithmTest {
         assertThat(testParameters.getIntersectionParam(), equalTo(newIntersectionDefault));
 
         assertThat(testParameters.getIntersectionParam(intersectionKey), equalTo(newIntersectionValue));
+
+        // Test that null-valued intersection parameter is removed
+        var deleteIntersectionConfig = new IntersectionConfig<Void>(TestParameters.INTERSECTION_PARAM, "", roadRegulatorId,
+                intersectionId, null, "", UnitsEnum.NONE, "");
+        intersectionListener.accept(deleteIntersectionConfig);
+
+        assertThat(testParameters.getIntersectionParam(), equalTo(newIntersectionDefault));
+        assertThat(testParameters.getIntersectionParam(intersectionKey), equalTo(newIntersectionDefault));
         
     }
 

--- a/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/testutils/ConfigTestUtils.java
+++ b/jpo-conflictmonitor/src/test/java/us/dot/its/jpo/conflictmonitor/testutils/ConfigTestUtils.java
@@ -117,7 +117,7 @@ public class ConfigTestUtils {
 
     public static IntersectionConfig<Integer> getIntersectionConfig_NoRegion() {
         var intersectionConfig = getIntersectionConfig();
-        intersectionConfig.setRoadRegulatorID(0);
+        intersectionConfig.setRoadRegulatorID(-1);
         return intersectionConfig;
     }
 
@@ -129,7 +129,7 @@ public class ConfigTestUtils {
         intersectionConfig.setUnits(units);
         intersectionConfig.setDescription(description);
         intersectionConfig.setIntersectionID(intersectionId);
-        intersectionConfig.setRoadRegulatorID(0);
+        intersectionConfig.setRoadRegulatorID(-1);
         intersectionConfig.setType(type);
         return intersectionConfig;
     }


### PR DESCRIPTION
Adds DELETE methods for intersection-level configuration settings to `ConfigController`.

Fixes handling of unspecified intersections in `ConfigController` and `ConfigTopology` to consistenly represent unspecified regions with -1 instead of 0.  Requires configuration settings posted to "unspecified region" endpoints to have RoadRegulatorID = -1 instead of 0.

New REST methods:

* DELETE {base URL}/config/intersection/{region}/{intersectionId}/{key}
    
   * Removes a value with region specified

* DELETE {base URL}/config/intersection/{intersectionId}/{key}
    
   * Removes a value with unspecified region

The delete methods work by sending 'tombstones' (keys with null values) to the configuration KTable topic, and triggering the intersection configuration listeners to remove the configuration settings from the `ConfigMap` of properties classes.

Tested with updated unit tests and new http integration tests in scripts/ConfigController_tests:
* deleteIntersection.http
* deleteIntersection_no_region.http
