### PR TITLE
Improve readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ git config core.longpaths true
 
 #### Step 1 - Download the Source Code
 
+Note: if you intend to run the entire ConflictVisualizer system, you should instead start with [step 1 of the ConflictVisualizer Installation Guide](https://github.com/usdot-jpo-ode/jpo-conflictvisualizer?tab=readme-ov-file#1-initialize-and-update-submodules) before returning to step 2 below.
+
 The jpo-geojsonconverter software system consists of the following modules hosted in separate Github repositories:
 
 |Name|Visibility|Description|
@@ -131,14 +133,6 @@ The jpo-geojsonconverter software system consists of the following modules hoste
 |[jpo-ode](https://github.com/usdot-jpo-ode/jpo-ode)|public|Contains the public classes and libraries of the jpo-ode used in the Conflict Monitor.|
 
 You may download the stable, default branch for ALL of these dependencies by using the following recursive git clone command:
-
-```bash
-git clone --recurse-submodules https://github.com/usdot-jpo-ode/jpo-ode.git
-```
-
-```bash
-git clone --recurse-submodules https://github.com/usdot-jpo-ode/jpo-geojsonconverter.git
-```
 
 ```bash
 git clone --recurse-submodules https://github.com/usdot-jpo-ode/jpo-conflictmonitor.git


### PR DESCRIPTION
This set of 3 matching pull requests aim to clarify a few points in the Readme installation instructions that slowed me down when I was installing the environment for the first time. I don't necessarily have a big-picture in mind around which components might or might not be designed to run independently, so please correct me if any of my additions are missing important context.