### PR TITLE
Updated ODE reference version in pom.xml to 2.0.0-SNAPSHOT

### DIFF
--- a/jpo-conflictmonitor/pom.xml
+++ b/jpo-conflictmonitor/pom.xml
@@ -99,12 +99,12 @@
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-core</artifactId>
-      <version>1.6.0-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>
       <artifactId>jpo-ode-plugins</artifactId>
-      <version>1.6.0-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>usdot.jpo.ode</groupId>


### PR DESCRIPTION
## Problem
The version of the ODE for the upcoming release has been updated in https://github.com/usdot-jpo-ode/jpo-ode/pull/537.

## Solution
The pom.xml has been updated to correctly reference the upcoming release version.