### PR TITLE
Broadcast Rate Events for MAPs and SPATs that stop being broadcasted

### DIFF
--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseValidationTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseValidationTopology.java
@@ -1,14 +1,7 @@
 package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;
 
-import java.time.Duration;
-import java.time.ZoneOffset;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.BaseStreamsTopology;
@@ -16,6 +9,11 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.ProcessingTimePeriod
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.MinimumDataEvent;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Common code for {@link MapValidationTopology} and {@link SpatValidationTopology}

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseValidationTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseValidationTopology.java
@@ -18,7 +18,7 @@ import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
 
 /**
- * Common code for {@link MapValidationTopology} and {@link SpatAssessmentsTopoloby}
+ * Common code for {@link MapValidationTopology} and {@link SpatValidationTopology}
  */
 public abstract class BaseValidationTopology<TParams>
     extends BaseStreamsTopology<TParams> {

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseZeroRateChecker.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseZeroRateChecker.java
@@ -1,0 +1,2 @@
+package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;public class BaseZeroRateChecker {
+}

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseZeroRateChecker.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseZeroRateChecker.java
@@ -1,6 +1,5 @@
 package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.api.Processor;
@@ -10,10 +9,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.slf4j.Logger;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.ProcessingTimePeriod;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.BroadcastRateEvent;
-import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
-import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 
 import java.time.Duration;
 

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseZeroRateChecker.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/BaseZeroRateChecker.java
@@ -1,2 +1,90 @@
-package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;public class BaseZeroRateChecker {
+package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.slf4j.Logger;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.ProcessingTimePeriod;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.BroadcastRateEvent;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
+
+import java.time.Duration;
+
+/**
+ * Base class for zero broadcast rate checker. Maintains a state store with the latest wall clock timestamp for each
+ * key, and emits events if the current time is more than the rolling window period later.
+ * @param <TItem> Type of input items, ProcessedMap or ProcessedSpat
+ * @param <TEvent> Type of output events
+ */
+public abstract class BaseZeroRateChecker<TItem, TEvent extends BroadcastRateEvent>
+    implements Processor<RsuIntersectionKey, TItem, RsuIntersectionKey, TEvent> {
+
+    protected abstract Logger getLogger();
+
+    protected abstract TEvent createEvent();
+
+    private KeyValueStore<RsuIntersectionKey, Long> store;
+    private final int maxAgeMillis;
+    private final int checkEveryMillis;
+    private final String inputTopicName;
+    private final String stateStoreName;
+
+    ProcessorContext<RsuIntersectionKey, TEvent> context;
+
+    public BaseZeroRateChecker(final int rollingPeriodSeconds, final int outputIntervalSeconds, final String inputTopicName, final String stateStoreName) {
+        this.maxAgeMillis = rollingPeriodSeconds * 1000;
+        this.checkEveryMillis = outputIntervalSeconds * 1000;
+        this.inputTopicName = inputTopicName;
+        this.stateStoreName = stateStoreName;
+    }
+
+    @Override
+    public void init(ProcessorContext<RsuIntersectionKey, TEvent> context) {
+        this.context = context;
+        this.store = context.getStateStore(stateStoreName);
+        context.schedule(Duration.ofMillis(checkEveryMillis),
+                PunctuationType.WALL_CLOCK_TIME,
+                this::punctuate);
+    }
+
+    @Override
+    public void process(Record<RsuIntersectionKey, TItem> record) {
+        store.put(record.key(), System.currentTimeMillis());
+    }
+
+    private void punctuate(long timestamp) {
+        // Check if any keys are older than the max age
+        try (var storeIterator = store.all()) {
+            while (storeIterator.hasNext()) {
+                KeyValue<RsuIntersectionKey, Long> item =storeIterator.next();
+                RsuIntersectionKey key = item.key;
+                Long lastTimestamp = item.value;
+                if (timestamp - lastTimestamp > maxAgeMillis) {
+                    emitZeroEvent(key, timestamp);
+                }
+            }
+        }
+    }
+
+    private void emitZeroEvent(RsuIntersectionKey key, long timestamp) {
+        getLogger().info("emit zero rate event for key = {} at timestamp = {}", key, timestamp);
+        TEvent event = createEvent();
+        event.setSource(key.toString());
+        event.setIntersectionID(key.getIntersectionId());
+        event.setRoadRegulatorID(key.getRegion());
+        event.setTopicName(inputTopicName);
+        ProcessingTimePeriod timePeriod = new ProcessingTimePeriod();
+        timePeriod.setBeginTimestamp(timestamp - maxAgeMillis);
+        timePeriod.setEndTimestamp(timestamp);
+        event.setTimePeriod(timePeriod);
+        event.setNumberOfMessages(0);
+        context.forward(new Record<>(key, event, timestamp));
+    }
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/MapZeroRateChecker.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/MapZeroRateChecker.java
@@ -1,21 +1,10 @@
 package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.processor.PunctuationType;
-import org.apache.kafka.streams.processor.api.Processor;
-import org.apache.kafka.streams.processor.api.ProcessorContext;
-import org.apache.kafka.streams.processor.api.Record;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.slf4j.Logger;
-import us.dot.its.jpo.conflictmonitor.monitor.algorithms.validation.map.MapValidationParameters;
-import us.dot.its.jpo.conflictmonitor.monitor.models.events.ProcessingTimePeriod;
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
-
-import java.time.Duration;
 
 
 @Slf4j

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/MapZeroRateChecker.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/MapZeroRateChecker.java
@@ -1,2 +1,80 @@
-package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;public class MapZeroRateChecker {
+package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+import us.dot.its.jpo.conflictmonitor.monitor.algorithms.validation.map.MapValidationParameters;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.ProcessingTimePeriod;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.MapBroadcastRateEvent;
+import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
+import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
+
+import java.time.Duration;
+
+
+public class MapZeroRateChecker implements Processor<RsuIntersectionKey, ProcessedMap<LineString>, RsuIntersectionKey, MapBroadcastRateEvent> {
+
+    private KeyValueStore<RsuIntersectionKey, Long> store;
+    private final int maxAgeMillis;
+    private final int checkEveryMillis;
+    private final String inputTopicName;
+
+    ProcessorContext<RsuIntersectionKey, MapBroadcastRateEvent> context;
+
+    public MapZeroRateChecker(MapValidationParameters parameters) {
+        this.maxAgeMillis = parameters.getRollingPeriodSeconds() * 1000;
+        this.checkEveryMillis = parameters.getOutputIntervalSeconds() * 1000;
+        this.inputTopicName = parameters.getInputTopicName();
+    }
+
+    @Override
+    public void init(ProcessorContext<RsuIntersectionKey, MapBroadcastRateEvent> context) {
+        this.context = context;
+        this.store = context.getStateStore(MapValidationTopology.LATEST_TIMESTAMP_STORE);
+        context.schedule(Duration.ofMillis(checkEveryMillis),
+                PunctuationType.WALL_CLOCK_TIME,
+                this::punctuate);
+    }
+
+    @Override
+    public void process(Record<RsuIntersectionKey, ProcessedMap<LineString>> record) {
+        store.put(record.key(), System.currentTimeMillis());
+    }
+
+    private void punctuate(long timestamp) {
+        // Check if any keys are older than the max age
+        try (var storeIterator = store.all()) {
+            while (storeIterator.hasNext()) {
+                KeyValue<RsuIntersectionKey, Long> item =storeIterator.next();
+                RsuIntersectionKey key = item.key;
+                Long lastTimestamp = item.value;
+                if (timestamp - lastTimestamp > maxAgeMillis) {
+                    emitZeroEvent(key, timestamp);
+                }
+            }
+        }
+    }
+
+    private void emitZeroEvent(RsuIntersectionKey key, long timestamp) {
+        var event = new MapBroadcastRateEvent();
+        event.setSource(key.toString());
+        event.setIntersectionID(key.getIntersectionId());
+        event.setRoadRegulatorID(key.getRegion());
+        event.setTopicName(inputTopicName);
+        ProcessingTimePeriod timePeriod = new ProcessingTimePeriod();
+        timePeriod.setBeginTimestamp(timestamp - maxAgeMillis);
+        timePeriod.setEndTimestamp(timestamp);
+        event.setTimePeriod(timePeriod);
+        event.setNumberOfMessages(0);
+        context.forward(new Record<>(key, event, timestamp));
+    }
+
+
+
+
+
 }

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/MapZeroRateChecker.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/MapZeroRateChecker.java
@@ -1,0 +1,2 @@
+package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;public class MapZeroRateChecker {
+}

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/SpatValidationTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/SpatValidationTopology.java
@@ -11,7 +11,6 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.validation.spat.SpatValidationParameters;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.validation.spat.SpatValidationStreamsAlgorithm;
@@ -20,7 +19,6 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.SpatB
 import us.dot.its.jpo.conflictmonitor.monitor.models.events.minimum_data.SpatMinimumDataEvent;
 import us.dot.its.jpo.conflictmonitor.monitor.serialization.JsonSerdes;
 import us.dot.its.jpo.geojsonconverter.partitioner.IntersectionIdPartitioner;
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuIdPartitioner;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
 

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/SpatValidationTopology.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/SpatValidationTopology.java
@@ -10,6 +10,7 @@ import org.apache.kafka.streams.kstream.Suppressed.BufferConfig;
 import org.apache.kafka.streams.state.WindowStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.validation.spat.SpatValidationParameters;
 import us.dot.its.jpo.conflictmonitor.monitor.algorithms.validation.spat.SpatValidationStreamsAlgorithm;
@@ -152,6 +153,7 @@ public class SpatValidationTopology
         
         return builder.build();
     }
+
 
 
     

--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/SpatZeroRateChecker.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/topologies/validation/SpatZeroRateChecker.java
@@ -1,0 +1,25 @@
+package us.dot.its.jpo.conflictmonitor.monitor.topologies.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import us.dot.its.jpo.conflictmonitor.monitor.models.events.broadcast_rate.SpatBroadcastRateEvent;
+import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
+
+@Slf4j
+public class SpatZeroRateChecker
+    extends BaseZeroRateChecker<ProcessedSpat, SpatBroadcastRateEvent> {
+
+    public SpatZeroRateChecker(int rollingPeriodSeconds, int outputIntervalSeconds, String inputTopicName, String stateStoreName) {
+        super(rollingPeriodSeconds, outputIntervalSeconds, inputTopicName, stateStoreName);
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+
+    @Override
+    protected SpatBroadcastRateEvent createEvent() {
+        return new SpatBroadcastRateEvent();
+    }
+}

--- a/jpo-conflictmonitor/src/main/resources/application.yaml
+++ b/jpo-conflictmonitor/src/main/resources/application.yaml
@@ -247,6 +247,7 @@ map.validation:
   debug: false
 
 
+
 # BSM Repartition
 repartition:
   algorithm: defaultRepartitionAlgorithm


### PR DESCRIPTION
Adds the ability to detect broadcast rates of 0, for example for RSUs that go offline that had previously been broadcasting MAPs and SPATs.

The existing Broadcast Rate Topologies count events in a window based on stream time to detect high or low rates, but do not work when there are no events coming in.

This PR adds `MapZeroRateChecker` and `SpatZeroRateChecker` processors to the MAP and SPaT validation topologies that work by storing the latest timestamp for each `RsuIntersectionKey` received, and using a wall-clock time triggered punctuator to emit a `BroadcastRateEvent` for any key whose last timestamp is older than the current time by more than the rolling window period (default 10 seconds).   The events are emitted at the configured output interval, which defaults to every 5 seconds, and continue being sent as long as the zero-broadcast-rate condition persists.