### PR TITLE
Schema Upgrade Support

### DIFF
--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/BsmDeduplicatorTopology.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/BsmDeduplicatorTopology.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import us.dot.its.jpo.deduplicator.deduplicator.processors.suppliers.OdeBsmJsonProcessorSupplier;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
 
 public class BsmDeduplicatorTopology {
 
@@ -44,7 +45,7 @@ public class BsmDeduplicatorTopology {
 
     public BsmDeduplicatorTopology(DeduplicatorProperties props){
         this.props = props;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = DateJsonMapper.getInstance();
         calculator = new GeodeticCalculator();
     }
 

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/MapDeduplicatorTopology.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/MapDeduplicatorTopology.java
@@ -11,6 +11,7 @@ import us.dot.its.jpo.conflictmonitor.monitor.models.bsm.BsmRsuIdKey;
 import us.dot.its.jpo.conflictmonitor.monitor.utils.BsmUtils;
 import us.dot.its.jpo.deduplicator.DeduplicatorProperties;
 import us.dot.its.jpo.deduplicator.deduplicator.processors.suppliers.OdeMapJsonProcessorSupplier;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIdPartitioner;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes;
@@ -49,8 +50,7 @@ public class MapDeduplicatorTopology {
     public MapDeduplicatorTopology(DeduplicatorProperties props, Properties streamsProperties){
         this.props = props;
         this.streamsProperties = streamsProperties;
-        this.objectMapper = new ObjectMapper();
-        
+        this.objectMapper = DateJsonMapper.getInstance();
     }
 
 

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/OdeRawEncodedTimDeduplicatorTopology.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/OdeRawEncodedTimDeduplicatorTopology.java
@@ -9,6 +9,7 @@ import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
 import us.dot.its.jpo.deduplicator.DeduplicatorProperties;
 import us.dot.its.jpo.deduplicator.deduplicator.serialization.JsonSerdes;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
 
 import org.apache.kafka.streams.kstream.*;
 import org.apache.kafka.streams.state.Stores;
@@ -40,7 +41,7 @@ public class OdeRawEncodedTimDeduplicatorTopology {
 
     public OdeRawEncodedTimDeduplicatorTopology(DeduplicatorProperties props, Properties streamsProperties){
         this.streamsProperties = streamsProperties;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = DateJsonMapper.getInstance();
         this.props = props;
     }
 

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/ProcessedMapDeduplicatorTopology.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/ProcessedMapDeduplicatorTopology.java
@@ -9,6 +9,7 @@ import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
 import us.dot.its.jpo.deduplicator.DeduplicatorProperties;
 import us.dot.its.jpo.deduplicator.deduplicator.processors.suppliers.ProcessedMapProcessorSupplier;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 import us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes;
@@ -34,7 +35,7 @@ public class ProcessedMapDeduplicatorTopology {
     public ProcessedMapDeduplicatorTopology(DeduplicatorProperties props, Properties streamsProperties){
         this.props = props;
         this.streamsProperties = streamsProperties;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = DateJsonMapper.getInstance();
     }
 
     

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/ProcessedMapWktDeduplicatorTopology.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/ProcessedMapWktDeduplicatorTopology.java
@@ -9,6 +9,7 @@ import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
 import us.dot.its.jpo.deduplicator.DeduplicatorProperties;
 import us.dot.its.jpo.deduplicator.deduplicator.processors.suppliers.ProcessedMapWktProcessorSupplier;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.map.ProcessedMap;
 import us.dot.its.jpo.geojsonconverter.serialization.JsonSerdes;
 
@@ -35,7 +36,7 @@ public class ProcessedMapWktDeduplicatorTopology {
     public ProcessedMapWktDeduplicatorTopology(DeduplicatorProperties props, Properties streamsProperties){
         this.props = props;
         this.streamsProperties = streamsProperties;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = DateJsonMapper.getInstance();
     }
 
     

--- a/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/TimDeduplicatorTopology.java
+++ b/jpo-deduplicator/src/main/java/us/dot/its/jpo/deduplicator/deduplicator/topologies/TimDeduplicatorTopology.java
@@ -8,6 +8,7 @@ import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
 import us.dot.its.jpo.deduplicator.deduplicator.serialization.JsonSerdes;
+import us.dot.its.jpo.geojsonconverter.DateJsonMapper;
 
 import org.apache.kafka.streams.kstream.*;
 import org.apache.kafka.streams.state.Stores;
@@ -38,7 +39,7 @@ public class TimDeduplicatorTopology {
     public TimDeduplicatorTopology(DeduplicatorProperties props, Properties streamsProperties) {
         this.props = props;
         this.streamsProperties = streamsProperties;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = DateJsonMapper.getInstance();
     }
 
     public void start() {


### PR DESCRIPTION
This PR includes the following changes:

1. Updated the submodule reference for the `jpo-geojsonconverter` to the latest commit on the develop branch
2. Changed the `jpo-deduplicator` to use the `DateJsonMapper.java` class for its object mapper. This object mapper will not error out when there are unknown properties.

All tests still pass and everything seems to work when running with the updated ODE metadata schema.