### PR TITLE
Tweak how bsm message count progression processor finds ID

### DIFF
--- a/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/processors/BsmMessageCountProgressionProcessor.java
+++ b/jpo-conflictmonitor/src/main/java/us/dot/its/jpo/conflictmonitor/monitor/processors/BsmMessageCountProgressionProcessor.java
@@ -165,7 +165,10 @@ public class BsmMessageCountProgressionProcessor<Point> extends ContextualProces
         event.setTimestampA(previousState.getTimeStamp().format(formatter));
         event.setMessageCountB(currentProperties.getMsgCnt());
         event.setTimestampB(thisState.getTimeStamp().format(formatter));
-        if (thisState.getFeatures()[featureIndex].getId() != null) {
+        if (thisState.getFeatures()[featureIndex].getProperties().getId() != null) {
+            event.setVehicleId(thisState.getFeatures()[featureIndex].getProperties().getId().toString());
+        }
+        else if (thisState.getFeatures()[featureIndex].getId() != null) {
             event.setVehicleId(thisState.getFeatures()[featureIndex].getId().toString());
         }
 


### PR DESCRIPTION
The updated changes to BSM Message Count Progression Processor check the properties of a ProcessedBsm for the vehicle ID, instead of checking the BSM directly. I added it as an additional first-place to search for the ID instead of replacing the existing logic, in case this behavior varies by environment.