### PR TITLE
Hotfix: fix GC option in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV LD_PRELOAD="/usr/lib64/libjemalloc.so"
 # Set max Java heap usage as percentage of total available memory.
 ENTRYPOINT ["java", \
 	"-Dlogback.configurationFile=/home/logback.xml", \
-    "-XX:+UseG3GC", \
+    "-XX:+UseG1GC", \
     "-XX:MaxGCPauseMillis=20", \
     "-XX:InitiatingHeapOccupancyPercent=35", \
     "-XX:MetaspaceSize=96m", \

--- a/jpo-conflictmonitor/pom.xml
+++ b/jpo-conflictmonitor/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>usdot.jpo.ode</groupId>
   <artifactId>jpo-conflictmonitor</artifactId>
-  <version>3.1.0</version>
+  <version>3.1.1</version>
   <packaging>jar</packaging>
   <name>jpo-conflictmonitor</name>
   <url>http://maven.apache.org</url>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Hotfix: fix GC option in Dockerfile preventing docker image from starting up in release jpo-conflictmonitor-3.1.0

Version number incremented to 3.1.1

## Motivation and Context

The release does not start in Docker with the default Dockerfile entrypoint.

## How Has This Been Tested?

Test procedure with Docker Desktop on Windows 11

```bash
git checkout jpo-conflictmonitor-3.1.0
docker compose up --build -d
````

View the log in the docker container.

Before applying the fix there is an error message:

```
Unrecognized VM option 'UseG3GC'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

After the fix, the container starts normally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
